### PR TITLE
Removed querySelector() from <ons-carousel> + Angular2 example.

### DIFF
--- a/tutorial/angular2/Reference/carousel.html
+++ b/tutorial/angular2/Reference/carousel.html
@@ -9,6 +9,7 @@
       Component,
       OnsenModule,
       NgModule,
+      ViewChild,
       CUSTOM_ELEMENTS_SCHEMA
     } from 'angular2-onsenui';
     import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
@@ -31,7 +32,7 @@
           </div>
         </ons-toolbar>
         <div class="content">
-          <ons-carousel fullscreen swipeable auto-scroll overscrollable id="carousel">
+          <ons-carousel #carousel fullscreen swipeable auto-scroll overscrollable id="carousel">
             <ons-carousel-item style="background-color: #085078;">
               <div style="text-align: center; font-size: 30px; margin-top: 20px; color: #fff;">
                 BLUE
@@ -53,11 +54,13 @@
       `
     })
     export class AppComponent {
+      @ViewChild('carousel') carousel;
+
       prev() {
-        document.querySelector('ons-carousel').prev();
+        this.carousel.nativeElement.prev();
       }
       next() {
-        document.querySelector('ons-carousel').next();
+        this.carousel.nativeElement.next();
       }
     }
 


### PR DESCRIPTION
@fran I forgot to remove querySelector() from examples in https://github.com/OnsenUI/tutorial/pull/14. Merge this changes if there is no problem.
