### PR TITLE
Move toolbars in tab pages to outside of the tabbar.

### DIFF
--- a/tutorial/vanilla/common_patterns/kitchensink.html
+++ b/tutorial/vanilla/common_patterns/kitchensink.html
@@ -43,6 +43,14 @@
         <ons-splitter-side id="sidemenu" page="sidemenu.html" swipeable side="right" collapse="" width="260px"></ons-splitter-side>
         <ons-splitter-content>
           <ons-page>
+            <ons-toolbar>
+              <div class="center">Kitchensink</div>
+              <div class="right">
+                <ons-toolbar-button onclick="fn.toggleMenu()">
+                  <ons-icon icon="ion-navicon, material:md-menu"></ons-icon>
+                </ons-toolbar-button>
+              </div>
+            </ons-toolbar>
             <ons-tabbar id="appTabbar" position="auto">
               <ons-tab label="Home" icon="ion-home" page="home.html" active></ons-tab>
               <ons-tab label="Forms" icon="ion-edit" page="forms.html"></ons-tab>
@@ -168,14 +176,6 @@
 
   <template id="home.html">
     <ons-page>
-      <ons-toolbar>
-        <div class="center">Home</div>
-        <div class="right">
-          <ons-toolbar-button onclick="fn.toggleMenu()">
-            <ons-icon icon="ion-navicon, material:md-menu"></ons-icon>
-          </ons-toolbar-button>
-        </div>
-      </ons-toolbar>
       <p class="intro">
         This is a kitchen sink example that shows off the components of Onsen UI.<br><br>
       </p>
@@ -227,14 +227,6 @@
 
   <template id="forms.html">
     <ons-page id="forms-page">
-      <ons-toolbar>
-        <div class="center">Forms</div>
-        <div class="right">
-          <ons-toolbar-button onclick="fn.toggleMenu()">
-            <ons-icon icon="ion-navicon, material:md-menu"></ons-icon>
-          </ons-toolbar-button>
-        </div>
-      </ons-toolbar>
       <ons-list>
         <ons-list-header>Text input</ons-list-header>
         <ons-list-item class="input-items">
@@ -454,14 +446,6 @@
 
   <template id="animations.html">
     <ons-page>
-      <ons-toolbar>
-        <div class="center">Animations</div>
-        <div class="right">
-          <ons-toolbar-button onclick="fn.toggleMenu()">
-            <ons-icon icon="ion-navicon, material:md-menu"></ons-icon>
-          </ons-toolbar-button>
-        </div>
-      </ons-toolbar>
       <ons-list>
         <ons-list-header>Transitions</ons-list-header>
         <ons-list-item modifier="chevron" onclick="fn.pushPage({'id': 'transition.html', 'title': 'none'}, 'none')">


### PR DESCRIPTION
@misterjunio (Cc: @masahiro )
Thank you for creating the kitchensink for Vanilla JS.
Just one thing, in Android view, tabs should be located *under* toolbars like https://frandiox.github.io/vue-onsenui-kitchensink/?platform=android .
So I removed toolbars from `home.html`, `forms.html` and `animation.html`, and put a toolbar to outside of the tabbar.

Could you please merge this if nothing is wrong?